### PR TITLE
Feat/update edit research button

### DIFF
--- a/components/Project/ProjectNavigation.vue
+++ b/components/Project/ProjectNavigation.vue
@@ -25,12 +25,12 @@ const route = useRoute()
       <span
         block
         md:hidden
-      >{{ 'BACK' }}</span>
+      >{{ "BACK" }}</span>
       <span
         hidden
         whitespace-nowrap
         md:block
-      >{{ 'BACK TO LIST' }}</span>
+      >{{ "BACK TO LIST" }}</span>
     </NavigationButton>
     <div
       flex
@@ -43,21 +43,21 @@ const route = useRoute()
         @click="$router.push('/project/' + route.params.id + '/edit')"
       >
         <span
-          text-16px
+          text-20px
           whitespace-nowrap
-          font-400
+          font-700
           leading-24px
           hidden
           md:block
-        >{{ 'EDIT RESEARCH' }}</span>
+        >{{ "EDIT RESEARCH" }}</span>
         <span
-          text-16px
+          text-20px
           whitespace-nowrap
-          font-400
+          font-700
           leading-24px
           block
           md:hidden
-        >{{ 'EDIT' }}</span>
+        >{{ "EDIT" }}</span>
       </EditButton>
       <!-- <ShareButton>
         <span text-16px font-400 hidden md:block>{{ 'SHARE' }}</span>

--- a/components/Project/ProjectNavigation.vue
+++ b/components/Project/ProjectNavigation.vue
@@ -25,12 +25,12 @@ const route = useRoute()
       <span
         block
         md:hidden
-      >{{ "BACK" }}</span>
+      >{{ 'BACK' }}</span>
       <span
         hidden
         whitespace-nowrap
         md:block
-      >{{ "BACK TO LIST" }}</span>
+      >{{ 'BACK TO LIST' }}</span>
     </NavigationButton>
     <div
       flex
@@ -49,7 +49,7 @@ const route = useRoute()
           leading-24px
           hidden
           md:block
-        >{{ "EDIT RESEARCH" }}</span>
+        >{{ 'EDIT RESEARCH' }}</span>
         <span
           text-20px
           whitespace-nowrap
@@ -57,7 +57,7 @@ const route = useRoute()
           leading-24px
           block
           md:hidden
-        >{{ "EDIT" }}</span>
+        >{{ 'EDIT' }}</span>
       </EditButton>
       <!-- <ShareButton>
         <span text-16px font-400 hidden md:block>{{ 'SHARE' }}</span>


### PR DESCRIPTION
Added bold text and increased the font size to make the edit research more prominent. See screenshot below. If this is still an issue I think maybe we can consider moving the button the red area in screenshot. However I wonder if that gives the impression you are only going to edit that section.

![edit research](https://github.com/user-attachments/assets/eaf4bc47-7136-475e-85e1-d5cdf4b30bc8)
