### PR TITLE
Add clean layout to about page

### DIFF
--- a/layouts/clean.vue
+++ b/layouts/clean.vue
@@ -1,0 +1,33 @@
+<script lang="ts" setup>
+const { showBar } = storeToRefs(useNavigaiton())
+const swipeEl = ref()
+const { y } = useWindowScroll()
+
+watch(y, (newY, oldY) => {
+  if (newY > oldY && newY > 32)
+    showBar.value = false
+  else
+    showBar.value = true
+})
+</script>
+
+<template>
+  <div
+    ref="swipeEl"
+    flex
+    flex-col
+    min-h-100vh
+    h-full
+    w-full
+  >
+    <Navigation />
+    <div
+      app-container
+      mt-32px
+      relative
+    >
+      <slot />
+    </div>
+    <Footer justify-self-end />
+  </div>
+</template>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -125,5 +125,7 @@
 </template>
 
 <script setup lang="ts">
-// This is a static content page — no interactivity needed
+definePageMeta({
+  layout: 'clean',
+})
 </script>


### PR DESCRIPTION
# Remove Search and Filters from About Page

## Changes Made
- Created new `clean.vue` layout without search bar and filters
- Modified `about.vue` to use the clean layout

## Why
The About page is a static informational page that doesn't need search or filtering functionality. This change:
- Improves user experience by removing irrelevant UI elements
- Reduces unnecessary component loading
- Makes the About page cleaner and more focused on its content

## Testing
- Verified About page loads without search bar and filters
- Confirmed other pages still maintain their filtering functionality