### PR TITLE
Fix: Correct navigation store name typo

### DIFF
--- a/components/NavigationOld.vue
+++ b/components/NavigationOld.vue
@@ -6,7 +6,7 @@ const isProjectRoute = computed(() => {
 })
 
 const showMenu = ref(false)
-const { showBar, showText } = storeToRefs(useNavigaiton())
+const { showBar, showText } = storeToRefs(useNavigation())
 const { width } = useWindowSize()
 const { y } = useWindowScroll()
 

--- a/composables/useNavigation.ts
+++ b/composables/useNavigation.ts
@@ -1,4 +1,4 @@
-export const useNavigaiton = defineStore('navigation', () => {
+export const useNavigation = defineStore('navigation', () => {
   const showBar = ref(true)
   const showText = ref(true)
 

--- a/layouts/clean.vue
+++ b/layouts/clean.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { showBar } = storeToRefs(useNavigaiton())
+const { showBar } = storeToRefs(useNavigation())
 const swipeEl = ref()
 const { y } = useWindowScroll()
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -18,7 +18,7 @@ const ecosystemOptions = ref<InputOption[]>(ecosystems.value ? [{ label: 'Ecosys
 const assetOptions = ref<InputOption[]>(assets.value ? [{ label: 'Asset used', value: 'all' }, ...assets.value.map(a => ({ label: `${a.id.toUpperCase()} (${a.name})`, value: a.id }))] : [])
 const featureOptions = ref<InputOption[]>(features.value ? [{ label: 'Feature', value: 'all' }, ...features.value.map(f => ({ label: f.name, value: f.id }))] : [])
 
-const { showBar } = storeToRefs(useNavigaiton())
+const { showBar } = storeToRefs(useNavigation())
 const swipeEl = ref()
 const { y } = useWindowScroll()
 const scrollEl = ref()

--- a/layouts/detail.vue
+++ b/layouts/detail.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-const { showBar } = storeToRefs(useNavigaiton())
+const { showBar } = storeToRefs(useNavigation())
 const swipeEl = ref()
 const { y } = useWindowScroll()
 


### PR DESCRIPTION
This PR fixes a typo in the navigation store name.

Changes made:
- Fixed store name from `useNavigaiton` to `useNavigation` in the store definition
- Updated all references to use the correct spelling in layouts and components

This should resolve the Vercel deployment failure by ensuring consistent store naming across the codebase.


